### PR TITLE
Fix eval scripts: missing default config and absolute hydra config_path

### DIFF
--- a/eval/cityscapes_val_mid.py
+++ b/eval/cityscapes_val_mid.py
@@ -11,7 +11,7 @@ import torch
 from PIL import Image
 from vggt.models.vggt import VGGT
 from typing import Optional
-from hydra import compose, initialize
+from hydra import compose, initialize_config_dir
 from hydra.utils import instantiate
 
 
@@ -75,6 +75,8 @@ def main():
         default="/data2/uqxsun14/backup/exp000_cityscapes_finetune_1/ckpts/checkpoint_6.pt",
         help="Checkpoint path for VGGT.",
     )
+    parser.add_argument("--config", default="default_cityscapes",
+                        help="hydra config name under training_fm/config (repo has no bare `default.yaml`)")
     args = parser.parse_args()
 
     sequence_list = build_sequence_list(args.cityscapes_dir, args.split)
@@ -83,7 +85,7 @@ def main():
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
     def load_model_from_config(config_name: str, ckpt_path: Optional[str], device: str):
-        with initialize(version_base=None, config_path=str(CONFIG_DIR)):
+        with initialize_config_dir(version_base=None, config_dir=str(CONFIG_DIR)):
             cfg = compose(config_name=config_name)
 
         model = instantiate(cfg.model, _recursive_=False)
@@ -107,7 +109,7 @@ def main():
             model.fm.eval()
         return model, cfg
 
-    model, cfg = load_model_from_config("default", args.ckpt, device)
+    model, cfg = load_model_from_config(args.config, args.ckpt, device)
     abs_rels = []
     delta1s = []
     with torch.no_grad():

--- a/eval/cityscapes_val_short.py
+++ b/eval/cityscapes_val_short.py
@@ -11,7 +11,7 @@ import torch
 from PIL import Image
 from vggt.models.vggt import VGGT
 from typing import Optional
-from hydra import compose, initialize
+from hydra import compose, initialize_config_dir
 from hydra.utils import instantiate
 
 
@@ -74,6 +74,8 @@ def main():
         "--ckpt",
         default="",
     )
+    parser.add_argument("--config", default="default_cityscapes",
+                        help="hydra config name under training_fm/config (repo has no bare `default.yaml`)")
     args = parser.parse_args()
     split = "val" if args.split == "test" else args.split
     device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -81,7 +83,7 @@ def main():
     sequence_list = build_sequence_list(args.cityscapes_dir, split)
 
     def load_model_from_config(config_name: str, ckpt_path: Optional[str], device: str):
-        with initialize(version_base=None, config_path=str(CONFIG_DIR)):
+        with initialize_config_dir(version_base=None, config_dir=str(CONFIG_DIR)):
             cfg = compose(config_name=config_name)
 
         model = instantiate(cfg.model, _recursive_=False)
@@ -105,7 +107,7 @@ def main():
             model.fm.eval()
         return model, cfg
 
-    model, cfg = load_model_from_config("default", args.ckpt, device)
+    model, cfg = load_model_from_config(args.config, args.ckpt, device)
     abs_rels = []
     delta1s = []
     with torch.no_grad():

--- a/eval/kitti_val_mid.py
+++ b/eval/kitti_val_mid.py
@@ -11,7 +11,7 @@ import torch
 from PIL import Image
 from vggt.models.vggt import VGGT
 from typing import Optional
-from hydra import compose, initialize
+from hydra import compose, initialize_config_dir
 from hydra.utils import instantiate
 
 
@@ -44,6 +44,8 @@ def main():
         "--ckpt",
         default="",
     )
+    parser.add_argument("--config", default="default_kitti",
+                        help="hydra config name under training_fm/config (repo has no bare `default.yaml`)")
     args = parser.parse_args()
 
     sequence_list = build_sequence_list(args.kitti_root, args.split)
@@ -52,7 +54,7 @@ def main():
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
     def load_model_from_config(config_name: str, ckpt_path: Optional[str], device: str):
-        with initialize(version_base=None, config_path=str(CONFIG_DIR)):
+        with initialize_config_dir(version_base=None, config_dir=str(CONFIG_DIR)):
             cfg = compose(config_name=config_name)
 
         model = instantiate(cfg.model, _recursive_=False)
@@ -76,7 +78,7 @@ def main():
             model.fm.eval()
         return model, cfg
 
-    model, cfg = load_model_from_config("default", args.ckpt, device)
+    model, cfg = load_model_from_config(args.config, args.ckpt, device)
     abs_rels_gt = []
     delta1s_gt = []
     abs_rels_vggt = []

--- a/eval/kitti_val_short.py
+++ b/eval/kitti_val_short.py
@@ -11,7 +11,7 @@ import torch
 from PIL import Image
 from vggt.models.vggt import VGGT
 from typing import Optional
-from hydra import compose, initialize
+from hydra import compose, initialize_config_dir
 from hydra.utils import instantiate
 
 
@@ -44,6 +44,8 @@ def main():
         "--ckpt",
         default="",
     )
+    parser.add_argument("--config", default="default_kitti",
+                        help="hydra config name under training_fm/config (repo has no bare `default.yaml`)")
     args = parser.parse_args()
 
     sequence_list = build_sequence_list(args.kitti_root, args.split)
@@ -52,7 +54,7 @@ def main():
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
     def load_model_from_config(config_name: str, ckpt_path: Optional[str], device: str):
-        with initialize(version_base=None, config_path=str(CONFIG_DIR)):
+        with initialize_config_dir(version_base=None, config_dir=str(CONFIG_DIR)):
             cfg = compose(config_name=config_name)
 
         model = instantiate(cfg.model, _recursive_=False)
@@ -76,7 +78,7 @@ def main():
             model.fm.eval()
         return model, cfg
 
-    model, cfg = load_model_from_config("default", args.ckpt, device)
+    model, cfg = load_model_from_config(args.config, args.ckpt, device)
     abs_rels_gt = []
     delta1s_gt = []
     abs_rels_vggt = []


### PR DESCRIPTION
The four scripts under `eval/` cannot run as shipped. Both failures happen at startup,
before any model work, so any of the four exits immediately.

### 1. `compose(config_name="default")` — no such config

`training_fm/config/` contains `default_kitti.yaml`, `default_cityscapes.yaml`,
`default_cityscapes_stage2.yaml` and `default_dataset.yaml`, but no bare `default.yaml`,
so all four scripts raise `MissingConfigException`.

Added a `--config` flag, defaulting to `default_kitti` for the KITTI scripts and
`default_cityscapes` for the Cityscapes ones, so the stage-2 config is also reachable:

```python
parser.add_argument("--config", default="default_kitti", ...)
model, cfg = load_model_from_config(args.config, args.ckpt, device)
```

### 2. `hydra.initialize()` rejects the absolute `CONFIG_DIR`

`CONFIG_DIR` is built from `Path(__file__).resolve()`, so it is absolute, but
`hydra.initialize()` only accepts a path relative to the caller:

```
HydraException: config_path in initialize() must be relative
```

`initialize_config_dir()` is the absolute-path equivalent:

```python
from hydra import compose, initialize_config_dir
with initialize_config_dir(version_base=None, config_dir=str(CONFIG_DIR)):
```

### Verification

With these two fixes and the released KITTI checkpoint, the paper's Table 1 numbers
reproduce on all 13 KITTI validation sequences:

| Setting | AbsRel (paper) | AbsRel (this branch) | δ1 (paper) | δ1 (this branch) |
|---|---|---|---|---|
| short (200 ms) | 0.065 | 0.0671 | 94.0 | 93.77 |
| mid (600 ms) | 0.098 | 0.1001 | 89.4 | 89.94 |

```bash
python eval/kitti_val_short.py --kitti_root /path/to/kitti --ckpt kitti.pt --config default_kitti
python eval/kitti_val_mid.py   --kitti_root /path/to/kitti --ckpt kitti.pt --config default_kitti
```

No behaviour changes beyond making the scripts start; the default config name preserves the
intended per-script behaviour.

### Minor, not changed here

`kitti_val_short.py` requires `len(frames) >= start_idx + step*sequence_length` = 17 frames
although it only indexes up to 15, so trimmed sequences fail the check unnecessarily. Left
alone to keep this PR to the two blocking bugs — happy to include it if you'd like.
